### PR TITLE
Put the files into the right place

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@libretto/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@libretto/core",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@libretto/redact-pii-light": "^1.0.1",
         "limiter": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/core",
   "main": "lib/src/index.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "types": "lib/src/index.d.ts",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "lib",
+    "rootDir": ".",
     "declaration": true
   },
   "include": ["src/**/*", "examples/**/*"]


### PR DESCRIPTION
The deployed library didn't have the right files exported.